### PR TITLE
Run Lint CI only once on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
Before Lint CI was called twice: one for pull_request, one for push. Now push action triggered only on master